### PR TITLE
Add to 'efm' general package warnings

### DIFF
--- a/autoload/vimtex/qf/latexlog.vim
+++ b/autoload/vimtex/qf/latexlog.vim
@@ -91,7 +91,9 @@ function! s:qf.set_errorformat() abort dict "{{{1
   "
   let l:default = self.config.packages.default
   if get(self.config.packages, 'natbib', l:default)
-    setlocal errorformat+=%+WPackage\ natbib\ Warning:\ %m\ on\ input\ line\ %l%.
+    setlocal errorformat+=%+WPackage\ natbib\ Warning:\ %m\ on\ input\ line\ %l.
+  else
+    setlocal errorformat+=%-WPackage\ natbib\ Warning:\ %m\ on\ input\ line\ %l.
   endif
 
   if get(self.config.packages, 'biblatex', l:default)
@@ -126,6 +128,10 @@ function! s:qf.set_errorformat() abort dict "{{{1
   if get(self.config.packages, 'titlesec', l:default)
     setlocal errorformat+=%+WPackage\ titlesec\ Warning:\ %m
     setlocal errorformat+=%-C(titlesec)%m
+  endif
+
+  if get(self.config.packages, 'general', l:default)
+    setlocal errorformat+=%+WPackage\ %.%#\ Warning:\ %m\ on\ input\ line\ %l.
   endif
 
   " Ignore unmatched lines

--- a/doc/vimtex.txt
+++ b/doc/vimtex.txt
@@ -1656,6 +1656,15 @@ OPTIONS                                                        *vimtex-options*
   and have to be specifically disabled. However, it is possible to use the
   entry `disable` to disable either all warnings, or all package warnings, if
   so desired.
+  Warnings by following packages can be disabled individually:
+  `babel`, `biblatex`, `fixltx2e`, `hyperref`, `natbib`, `scrreprt`, and `titlesec`.
+  The entry `general` under packages can be used to turn off messages of
+  packages matching the pattern >
+
+    Package .* Warning: %m on input line %l.
+<
+  Note: Messages by `natbib` follow also this pattern but have to be turned
+        off with the entry `natbib`.
 
   Some examples may be helpful: >
 
@@ -1685,12 +1694,13 @@ OPTIONS                                                        *vimtex-options*
           \ 'font' : 1,
           \ 'packages' : {
           \   'default' : 1,
-          \   'natbib' : 1,
-          \   'biblatex' : 1,
+          \   'general' : 1,
           \   'babel' : 1,
-          \   'hyperref' : 1,
-          \   'scrreprt' : 1,
+          \   'biblatex' : 1,
           \   'fixltx2e' : 1,
+          \   'hyperref' : 1,
+          \   'natbib' : 1,
+          \   'scrreprt' : 1,
           \   'titlesec' : 1,
           \ },
           \}


### PR DESCRIPTION
when using parser 'latexlog'. E.g. warnings by the package 'refcheck' are now shown.

However, others are still missing, e.g. following multi-line warning by onlyamsmath

Package onlyamsmath Warning: Environment eqnarray or eqnarray* used, please use
(onlyamsmath) only the environments provided by the amsmath
(onlyamsmath) package on input line 18.